### PR TITLE
fix(setup): add DA3 package to uv project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "imageio>=2.30.0",
     "imageio-ffmpeg>=0.4.7",
     "decord>=0.6.0",
+    "depth-anything-3",
 ]
 
 [project.scripts]
@@ -62,6 +63,9 @@ dev-dependencies = [
     "flake8>=7.2.0",
     "mypy>=1.0.0",
 ]
+
+[tool.uv.sources]
+depth-anything-3 = { git = "https://github.com/ByteDance-Seed/Depth-Anything-3" }
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
- uv project is required to have the DA3 source configured to install properly.
- Requires to specify Python 3.12 with `uv python pin 3.12` Or specify 3.12 as required in the project.

Related #11

```
uv venv --python 3.12
```

May also work. 