### PR TITLE
fix(setup): Move Linux and Windows install to UV wheelnext environment for auto GPU detection. (#13)

### DIFF
--- a/check_cuda.sh
+++ b/check_cuda.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+uv run src/depth_surge_3d/utils/system/check_cuda.py

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,15 +1,13 @@
-$gpu = Get-WmiObject Win32_VideoController | Select-Object -ExpandProperty Name
+#winget install --id=astral-sh.uv -e
+$env:INSTALLER_DOWNLOAD_URL='https://wheelnext.astral.sh'; 
+irm https://astral.sh/uv/install.ps1 | iex
 
-python -m venv venv
-venv\Scripts\activate
-pip install --upgrade pip
-pip install -r requirements.txt
+$env:UV_LINK_MODE='copy';
 
-if ($gpu -match "NVIDIA") {
-    pip install torch torchvision --index-url https://download.pytorch.org/whl/cu130
-} else {
-    pip install torch torchvision
-}
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User") 
+uv python install 3.12
+uv python pin 3.12
+uv sync
 
 
 $depthAnythingDir = "video_depth_anything_repo"

--- a/setup.sh
+++ b/setup.sh
@@ -24,6 +24,11 @@ fi
 
 echo "[OK] Python $python_version found"
 
+
+# Force Wheelnext UV installation. For automatic GPU variabt torch installation.
+curl -LsSf https://astral.sh/uv/install.sh | INSTALLER_DOWNLOAD_URL=https://wheelnext.astral.sh sh
+
+
 # Check for uv package manager
 if command_exists uv; then
     echo "[OK] uv package manager found - using for fast setup"
@@ -37,9 +42,14 @@ else
     use_uv=false
 fi
 
+use_uv=true
+
 # Setup virtual environment and dependencies
 if [ "$use_uv" = true ]; then
     echo "Setting up environment with uv..."
+    # Install required python 3.12
+    uv python install 3.12
+    uv python pin 3.12
     uv sync
 else
     echo "Setting up environment with pip..."


### PR DESCRIPTION
UV won't install the GPU Torch in Windows but the wheelnext UV should automatically detect the GPU (nvidia,amd,intel) and install the right version of Torch. 

I think UV is the best method for GPU support over pip. 

UV can be used to install the required Python 3.12.

- Install UV wheelnext in Linux script and force uv over pip.
- Install UV wheelnext in Windows setup script.
- Use UV to install and pin Python 3.12
- Add the check cuda helper script.

The nvidia provider plugin is broken on Windows for now.

https://github.com/wheelnext/nvidia-variant-provider/issues/8